### PR TITLE
Add security considerations for document validity, fragments, security assumptions.

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -197,7 +197,20 @@ as the text is terse in nature.
     </section>
     <section anchor="security-considerations">
       <name>Security Considerations</name>
-      <section anchor="media-type-fibbing">
+      <section anchor="ss-validity">
+        <name>Document Validity</name>
+        <t>
+If a toolchain chooses to process a provided media type by using the selected
+structured suffix processing rules, it cannot presume that a document that is
+valid per the decoding rules associated with the structured suffix
+will be valid for a recognized subset of the structured suffix. For example,
+presuming a media type of "application/foo+bar+baz", a toolchain cannot presume
+that a valid "+baz" document will also be a valid "+bar+baz" document or a
+valid "application/foo+bar+baz" document.
+        </t>
+      </section>
+
+      <section anchor="ss-fibbing">
         <name>Media Type Fibbing</name>
         <t>
 It is possible for an attacker to utilize multiple structured suffixes in a way

--- a/index.xml
+++ b/index.xml
@@ -217,8 +217,8 @@ If a toolchain chooses to process a provided media type by using the selected
 structured suffix processing rules, it cannot presume that fragment identifier
 semantics will be the same across a recognized subset of the structured suffix.
 For example, presuming a media type of "application/foo+bar+baz", a toolchain
-cannot presume that the fragment semantics or a "+baz" document will
-be the same as for a "+bar+baz" document or the same for an
+cannot presume that the fragment semantics for a "+baz" document will
+be the same as for a "+bar+baz" document or the same as for an
 "application/foo+bar+baz" document.
         </t>
       </section>

--- a/index.xml
+++ b/index.xml
@@ -210,6 +210,20 @@ valid "application/foo+bar+baz" document.
         </t>
       </section>
 
+      <section anchor="ss-fragments">
+        <name>Fragment Semantics</name>
+        <t>
+If a toolchain chooses to process a provided media type by using the selected
+structured suffix processing rules, it cannot presume that fragment identifier
+semantics will be the same across a recognized subset of the structured suffix.
+For example, presuming a media type of "application/foo+bar+baz", a toolchain
+cannot presume that the fragment semantics or a "+baz" document will
+be the same as for a "+bar+baz" document or the same for an
+"application/foo+bar+baz" document.
+        </t>
+      </section>
+
+
       <section anchor="ss-fibbing">
         <name>Media Type Fibbing</name>
         <t>

--- a/index.xml
+++ b/index.xml
@@ -223,6 +223,17 @@ be the same as for a "+bar+baz" document or the same for an
         </t>
       </section>
 
+      <section anchor="ss-security">
+        <name>Suffix Security Characteristics</name>
+        <t>
+Toolchains cannot assume that the security characteristics of processing based
+on structured suffixes will be the same for the entire media type or any
+combination of recognized structured suffixes. For example, presuming a media
+type of "application/foo+bar+baz", a toolchain cannot presume that the
+security considerations for a "+baz" document will be the same as for a
+"+bar+baz" document or the same for an "application/foo+bar+baz" document.
+        </t>
+      </section>
 
       <section anchor="ss-fibbing">
         <name>Media Type Fibbing</name>


### PR DESCRIPTION
This PR attempts to address feedback from @mnot by making the following changes:

* Add security considerations section on structures suffix security.
* Add security considerations section on fragment semantics.
* Add security considerations section on document validity.
